### PR TITLE
Craft 5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wbrowar/craft-little-layout",
     "description": "A compact, visual way to lay out fields, elements, and Matrix blocks.",
     "type": "craft-plugin",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "keywords": [
         "craft",
         "cms",
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0"
+        "craftcms/cms": "^4.0.0|^5.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/fields/Layout.php
+++ b/src/fields/Layout.php
@@ -77,6 +77,15 @@ class Layout extends Field
         return Craft::t('little-layout', 'Little Layout');
     }
 
+
+    /**
+     * @inheritdoc
+     */
+    public static function icon(): string
+    {
+        return Craft::getAlias('@wbrowar/littlelayout/icon.svg');
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/icon.svg
+++ b/src/icon.svg
@@ -1,13 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 99 99" style="enable-background:new 0 0 99 99;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#7E9FC3;stroke:#7A9ABD;stroke-width:2;stroke-miterlimit:10;}
-	.st1{fill:#6D88A8;stroke:#7A9ABD;stroke-width:2;stroke-miterlimit:10;}
-	.st2{fill:#A4C0DE;stroke:#7A9ABD;stroke-width:2;stroke-miterlimit:10;}
-</style>
-<rect x="36.4" y="35" class="st0" width="26.2" height="27.6"/>
-<path class="st1" d="M6.9,35c-2,0-3.6,1.6-3.6,3.6v20.4c0,2,1.6,3.6,3.6,3.6h23.6V35H6.9z"/>
-<path class="st2" d="M92.1,35H68.5v27.6h23.6c2,0,3.6-1.6,3.6-3.6V38.7C95.8,36.7,94.1,35,92.1,35z"/>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 99 99">
+  <path fill="#7e9fc3" stroke="#7a9abd" stroke-miterlimit="10" stroke-width="2" d="M36.4 35h26.2v27.6H36.4z"/>
+  <path fill="#6d88a8" stroke="#7a9abd" stroke-miterlimit="10" stroke-width="2" d="M6.9 35c-2 0-3.6 1.6-3.6 3.6V59c0 2 1.6 3.6 3.6 3.6h23.6V35H6.9z"/>
+  <path fill="#a4c0de" stroke="#7a9abd" stroke-miterlimit="10" stroke-width="2" d="M92.1 35H68.5v27.6h23.6c2 0 3.6-1.6 3.6-3.6V38.7c.1-2-1.6-3.7-3.6-3.7z"/>
 </svg>


### PR DESCRIPTION
Updated composer to allow for Craft 5 installations.
Optimised the icon SVG so as to be more suitable if used as raw markup.
Added icon reference for the field.